### PR TITLE
Fixed stackeditRender.js display mode

### DIFF
--- a/stackeditRender.js
+++ b/stackeditRender.js
@@ -73,7 +73,7 @@ function katexRender(){
             var katexDefinition = currElement.textContent;
 
             try{
-                var katexHTML = katex.renderToString(katexDefinition);
+                var katexHTML = katex.renderToString(katexDefinition, {displayMode: currElement.className=="katex--display"});
                 currElement.insertAdjacentHTML('beforebegin', katexHTML);
                 currElement.remove();
             }


### PR DESCRIPTION
stackeditRender.js was treating "display" and "inline" mode equation equally. No longer the case.